### PR TITLE
Added github repo to dist metadata and main module doc

### DIFF
--- a/Changes
+++ b/Changes
@@ -66,3 +66,5 @@ Revision history for Thrift-API-HiveClient2
 0.020   2015-10-01
         Removed .iml file
         Updated build dep for rpmbuild and older perl versions
+        Added [GithubMeta] to dist.ini, so repo will appear in dist metadata
+        Added link to github repo in the doc

--- a/dist.ini
+++ b/dist.ini
@@ -38,3 +38,5 @@ exclude_match     = .*.iml
 
 [PkgDist]
 [PkgVersion]
+
+[GithubMeta]

--- a/lib/Thrift/API/HiveClient2.pm
+++ b/lib/Thrift/API/HiveClient2.pm
@@ -610,6 +610,10 @@ L<https://groups.google.com/a/cloudera.org/d/msg/cdh-user/AXeEuaFP0Ro/Txmn1OHleA
 So we had to change the init script for hive-server2 to make it behave, adding
 '-Dfile.encoding=UTF-8' to HADOOP_OPTS
 
+=head1 REPOSITORY
+
+L<https://github.com/dmorel/Thrift-API-HiveClient2>
+
 =head1 CONTRIBUTORS
 
 Burak Gürsoy (BURAK)


### PR DESCRIPTION
Hi David,

This adds the github repo to the dist's metadata, so it will appear in the sidebar in MetaCPAN, and also makes it a candidate for the [CPAN Pull Request Challenge](http://cpan-prc.org).

Cheers,
Neil
