### PR TITLE
Don’t try to close undefined transport during global destruction

### DIFF
--- a/lib/Thrift/API/HiveClient2.pm
+++ b/lib/Thrift/API/HiveClient2.pm
@@ -492,7 +492,10 @@ sub DEMOLISH {
             )
         );
     }
-    $self->_transport->close;
+    
+    if ( $self->_transport ) {
+        $self->_transport->close;
+    }
 }
 
 # when the user calls a method on an object of this class, see if that method


### PR DESCRIPTION
I’ve been seeing the following error when a script exits:

> (in cleanup) Can't call method "close" on an undefined value at /home/lpadm/.perl5/perlbrew/perls/perl-5.24.1/lib/site_perl/5.24.1/Thrift/API/HiveClient2.pm line 499 during global destruction.

This commit ensures that `$self->_transport` exists before attempting to call the `close` method.